### PR TITLE
use 7z instead of unar to split packages

### DIFF
--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -203,7 +203,7 @@ class DSpace(models.Model):
         # TODO Should output dir be a temp dir?
         output_dir = os.path.dirname(input_path) + '/'
         dirname = os.path.splitext(os.path.basename(input_path))[0]
-        command = ['unar', '-force-overwrite', '-output-directory', output_dir, input_path]
+        command = ['7z', 'x', '-bd', '-y', '-o{0}'.format(output_dir), input_path]
         try:
             subprocess.check_call(command)
         except subprocess.CalledProcessError:


### PR DESCRIPTION
While testing Archivematica 1.9 on dev, depositing to DSpace failed from time to time during the `_split_package` step. Specifically, the step of initially extracting the Archivematica .7z package was failing with a "Wrong checksum" error on some Archivematica normalized files. I took a look at known Archivematica issues and think this is related to this issue: https://github.com/archivematica/Issues/issues/594

The solution, which I have tested on dev, is to replace `unar` with `7z` to extract the AIP. This is implemented here using the same command implemented in the following pull request to extract compressed files that have been 7z compressed: https://github.com/artefactual/archivematica-storage-service/pull/441/files

